### PR TITLE
Fix buffer head shift because of advance len check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.89"
 atoi = "2.0.0"
+byteorder = "1.5.0"
 bytes = "1.7.2"
 clap = { version = "4.5.20", features = ["derive"] }
 futures = "0.3.31"

--- a/src/actioner.rs
+++ b/src/actioner.rs
@@ -46,7 +46,7 @@ pub async fn handle(
                 let task = Task::new(0);
                 task_table.create(task).await;
                 let resp_msg = XMessage::BulkMessage(format!(
-                    "{}\n\n{}\n",
+                    "{}\n{}\n",
                     worker_table.render().await,
                     task_table.render().await,
                 ));


### PR DESCRIPTION
When the message size is very large, I encounter the issue that the message is not correctly decoded.
The bug was from using get_u32 which will advance the buffer there fore the next read of buffer for message len give the wrong length of stream. Change to use peek method solve the problem.

Thanks chatGPT.