### PR TITLE
Handshake fn for clients as interface

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,14 +7,14 @@ use tokio_util::codec::Framed;
 use crate::codec::Codec;
 use crate::codec::XMessage;
 
-pub enum Client {
-    Worker { id: u32, stream: TcpStream },
-    Actioner { id: u32, stream: TcpStream },
+pub enum Hook {
+    Worker { stream: TcpStream },
+    Actioner { stream: TcpStream },
 }
 
 // Perform handshake, decide client type (worker or actioner) and protocol (always messagepack)
 // XXX: hyperequeue seems doesn't have handshake stage, how??
-pub async fn handshake(stream: TcpStream) -> anyhow::Result<Client> {
+pub async fn handshake(stream: TcpStream) -> anyhow::Result<Hook> {
     let mut frame = Framed::new(stream, Codec::<XMessage>::new());
 
     frame
@@ -27,12 +27,12 @@ pub async fn handshake(stream: TcpStream) -> anyhow::Result<Client> {
                 "worker" => {
                     frame.send(XMessage::HandShake("Go".to_string())).await?;
                     let stream = frame.into_inner();
-                    Client::Worker { id: 0, stream }
+                    Hook::Worker { stream }
                 }
                 "actioner" => {
                     frame.send(XMessage::HandShake("Go".to_string())).await?;
                     let stream = frame.into_inner();
-                    Client::Actioner { id: 0, stream }
+                    Hook::Actioner { stream }
                 }
                 _ => anyhow::bail!("unknown client: {info:#?}"),
             },

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,41 @@
+use crate::codec::{Codec, XMessage};
+
+use futures::SinkExt;
+use tokio::net::TcpStream;
+use tokio_stream::StreamExt;
+use tokio_util::codec::Framed;
+
+#[derive(Debug)]
+pub enum ClientType {
+    Worker,
+    Actioner, 
+}
+
+pub async fn handshake(stream: TcpStream, client_t: ClientType) -> anyhow::Result<TcpStream> {
+    let mut framed = Framed::new(stream, Codec::<XMessage>::new());
+
+    loop {
+        if let Some(Ok(message)) = framed.next().await {
+            match message {
+                XMessage::HandShake(info) => match info.as_str() {
+                    "Go" => {
+                        println!("handshake successful!");
+                        break;
+                    }
+                    "Who you are?" => match client_t {
+                        ClientType::Worker => framed
+                            .send(XMessage::HandShake("worker".to_string()))
+                            .await?,
+                        ClientType::Actioner => framed
+                            .send(XMessage::HandShake("actioner".to_string()))
+                            .await?,
+                    }
+                    _ => eprintln!("unknown handshake info: {info}"),
+                },
+                _ => eprintln!("unknown message: {message:#?}"),
+            }
+        }
+    }
+
+    Ok(framed.into_inner())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,5 @@ pub mod assign;
 pub mod client;
 
 pub mod actioner;
+
+pub mod interface;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use tokio::net::TcpListener;
 use tatzelwurm::{actioner, task, worker};
 use tatzelwurm::{
     assign::assign,
-    client::{handshake, Client},
+    client::{self, handshake},
 };
 
 #[tokio::main]
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
                 let task_table_clone = task_table.clone();
 
                 match handshake(stream).await {
-                    Ok(Client::Worker { stream, .. }) => {
+                    Ok(client::Hook::Worker { stream }) => {
                         tokio::spawn(async move {
                             // TODO: process_stream shouldn't return, using tracing to recording logs and
                             // handling errors
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
                                 worker::handle(stream, worker_table_clone, task_table_clone).await;
                         });
                     }
-                    Ok(Client::Actioner { stream, .. }) => {
+                    Ok(client::Hook::Actioner { stream }) => {
                         tokio::spawn(async move {
                             // TODO: process_stream shouldn't return, using tracing to recording logs and
                             // handling errors

--- a/src/task.rs
+++ b/src/task.rs
@@ -180,7 +180,6 @@ impl Table {
                     .entry(State::Terminated(x))
                     .and_modify(|e| *e += 1)
                     .or_insert(1),
-                _ => todo!(),
             };
         }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use futures::SinkExt;
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};


### PR DESCRIPTION
Move the `handshake` function of clients bin implementation to the lib. This cut the number of lines in actioner/worker codes.
The goal is try to keep the binary implementation very short and use more interfaces as possible so even able to wrap interfaces with pyo3 for future impl.